### PR TITLE
[feat] Pet CRUD 구현

### DIFF
--- a/be/src/main/java/buddyguard/mybuddyguard/login/repository/UserRepository.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/login/repository/UserRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<Users, Long> {
     Users findByOauthId(String oAuthId);
+
+    boolean existsById(Long id);
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/PetController.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/PetController.java
@@ -1,0 +1,27 @@
+package buddyguard.mybuddyguard.pet.contoller;
+
+import buddyguard.mybuddyguard.pet.contoller.request.PetRegisterRequest;
+import buddyguard.mybuddyguard.pet.service.PetService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Controller
+public class PetController {
+
+    private final PetService service;
+
+    public PetController(PetService service) {
+        this.service = service;
+    }
+
+    // 반려동물 등록
+    @PostMapping("/pet")
+    public ResponseEntity<?> registerPet(@RequestBody PetRegisterRequest petRegisterRequest) {
+
+        service.register(petRegisterRequest);
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/PetController.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/PetController.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -36,5 +37,13 @@ public class PetController {
         List<PetWithUserListResponse> response = service.getPetWithUser(userId);
 
         return ResponseEntity.ok(response);
+    }
+
+    // 반려동물 삭제
+    @DeleteMapping("/pet/{userId}/{petId}")
+    public ResponseEntity<?> deletePet(@PathVariable("userId") Long userId,
+            @PathVariable("petId") Long petId) {
+        service.delete(userId, petId);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/PetController.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/PetController.java
@@ -1,29 +1,31 @@
 package buddyguard.mybuddyguard.pet.contoller;
 
 import buddyguard.mybuddyguard.pet.contoller.request.PetRegisterRequest;
+import buddyguard.mybuddyguard.pet.contoller.request.PetUpdateInformationRequest;
 import buddyguard.mybuddyguard.pet.contoller.response.PetWithUserListResponse;
 import buddyguard.mybuddyguard.pet.service.PetService;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/pet")
 public class PetController {
 
     private final PetService service;
 
-    public PetController(PetService service) {
-        this.service = service;
-    }
-
     // 반려동물 등록
-    @PostMapping("/pet")
+    @PostMapping
     public ResponseEntity<?> registerPet(@RequestBody PetRegisterRequest petRegisterRequest) {
 
         service.register(petRegisterRequest);
@@ -31,7 +33,7 @@ public class PetController {
     }
 
     // 회원과 연결된 반려동물 조회
-    @GetMapping("/pet/{userId}")
+    @GetMapping("/{userId}")
     public ResponseEntity<List<PetWithUserListResponse>> getPetWithUser(
             @PathVariable("userId") Long userId) {
         List<PetWithUserListResponse> response = service.getPetWithUser(userId);
@@ -40,10 +42,19 @@ public class PetController {
     }
 
     // 반려동물 삭제
-    @DeleteMapping("/pet/{userId}/{petId}")
+    @DeleteMapping("/{userId}/{petId}")
     public ResponseEntity<?> deletePet(@PathVariable("userId") Long userId,
             @PathVariable("petId") Long petId) {
         service.delete(userId, petId);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    // 반려동물 수정
+    @PatchMapping("/{userId}/{petId}")
+    public ResponseEntity<?> updatePetInformation(@PathVariable("userId") Long userId,
+            @PathVariable("petId") Long petId,
+            @RequestBody PetUpdateInformationRequest petUpdateInformationRequest) {
+        service.update(userId, petId, petUpdateInformationRequest);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/PetController.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/PetController.java
@@ -41,6 +41,15 @@ public class PetController {
         return ResponseEntity.ok(response);
     }
 
+    // 회원과 연관된 특정 반려동물 조회
+    @GetMapping("/{userId}/{petId}")
+    public ResponseEntity<?> getOnePetWithUser(@PathVariable("userId") Long userId,
+            @PathVariable("petId") Long petId) {
+        PetWithUserListResponse response = service.getOnePetWithUser(userId, petId);
+
+        return ResponseEntity.ok(response);
+    }
+
     // 반려동물 삭제
     @DeleteMapping("/{userId}/{petId}")
     public ResponseEntity<?> deletePet(@PathVariable("userId") Long userId,

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/PetController.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/PetController.java
@@ -24,15 +24,12 @@ public class PetController {
 
     private final PetService service;
 
-    // 반려동물 등록
     @PostMapping
-    public ResponseEntity<?> registerPet(@RequestBody PetRegisterRequest petRegisterRequest) {
-
+    public ResponseEntity<Void> registerPet(@RequestBody PetRegisterRequest petRegisterRequest) {
         service.register(petRegisterRequest);
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
-    // 회원과 연결된 반려동물 조회
     @GetMapping("/{userId}")
     public ResponseEntity<List<PetWithUserListResponse>> getPetWithUser(
             @PathVariable("userId") Long userId) {
@@ -41,26 +38,23 @@ public class PetController {
         return ResponseEntity.ok(response);
     }
 
-    // 회원과 연관된 특정 반려동물 조회
     @GetMapping("/{userId}/{petId}")
-    public ResponseEntity<?> getOnePetWithUser(@PathVariable("userId") Long userId,
-            @PathVariable("petId") Long petId) {
+    public ResponseEntity<PetWithUserListResponse> getOnePetWithUser(
+            @PathVariable("userId") Long userId, @PathVariable("petId") Long petId) {
         PetWithUserListResponse response = service.getOnePetWithUser(userId, petId);
 
         return ResponseEntity.ok(response);
     }
 
-    // 반려동물 삭제
     @DeleteMapping("/{userId}/{petId}")
-    public ResponseEntity<?> deletePet(@PathVariable("userId") Long userId,
+    public ResponseEntity<Void> deletePet(@PathVariable("userId") Long userId,
             @PathVariable("petId") Long petId) {
         service.delete(userId, petId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    // 반려동물 수정
     @PatchMapping("/{userId}/{petId}")
-    public ResponseEntity<?> updatePetInformation(@PathVariable("userId") Long userId,
+    public ResponseEntity<Void> updatePetInformation(@PathVariable("userId") Long userId,
             @PathVariable("petId") Long petId,
             @RequestBody PetUpdateInformationRequest petUpdateInformationRequest) {
         service.update(userId, petId, petUpdateInformationRequest);

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/PetController.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/PetController.java
@@ -1,10 +1,14 @@
 package buddyguard.mybuddyguard.pet.contoller;
 
 import buddyguard.mybuddyguard.pet.contoller.request.PetRegisterRequest;
+import buddyguard.mybuddyguard.pet.contoller.response.PetWithUserListResponse;
 import buddyguard.mybuddyguard.pet.service.PetService;
+import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -23,5 +27,14 @@ public class PetController {
 
         service.register(petRegisterRequest);
         return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    // 회원과 연결된 반려동물 조회
+    @GetMapping("/pet/{userId}")
+    public ResponseEntity<List<PetWithUserListResponse>> getPetWithUser(
+            @PathVariable("userId") Long userId) {
+        List<PetWithUserListResponse> response = service.getPetWithUser(userId);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/request/PetRegisterRequest.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/request/PetRegisterRequest.java
@@ -1,0 +1,16 @@
+package buddyguard.mybuddyguard.pet.contoller.request;
+
+import buddyguard.mybuddyguard.pet.utils.PetType;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+public record PetRegisterRequest(
+        @JsonProperty("user_id") @NotNull Long userId,
+        @NotNull String name,
+        @JsonProperty("profile_image") @NotNull String profileImage,
+        @NotNull PetType type,
+        @NotNull LocalDate birth
+) {
+
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/request/PetUpdateInformationRequest.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/request/PetUpdateInformationRequest.java
@@ -1,0 +1,12 @@
+package buddyguard.mybuddyguard.pet.contoller.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDate;
+
+public record PetUpdateInformationRequest(
+        String name,
+        @JsonProperty("profile_image") String profileImage,
+        LocalDate birth
+) {
+
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/response/PetWithUserListResponse.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/response/PetWithUserListResponse.java
@@ -1,0 +1,10 @@
+package buddyguard.mybuddyguard.pet.contoller.response;
+
+public record PetWithUserListResponse(
+        Long userId,
+        Long petId,
+        String petName,
+        String profileImage
+) {
+
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/entity/Pet.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/entity/Pet.java
@@ -23,6 +23,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Builder
 public class Pet {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -32,4 +33,16 @@ public class Pet {
     @Enumerated(EnumType.STRING)
     private PetType type;
     private LocalDate birth;
+
+    public void update(String name, String profileImage, LocalDate birth) {
+        if (name != null) {
+            this.name = name;
+        }
+        if (profileImage != null) {
+            this.profileImage = profileImage;
+        }
+        if (birth != null) {
+            this.birth = birth;
+        }
+    }
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/entity/Pet.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/entity/Pet.java
@@ -3,6 +3,8 @@ package buddyguard.mybuddyguard.pet.entity;
 import buddyguard.mybuddyguard.pet.utils.PetType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,6 +29,7 @@ public class Pet {
     private String name;
     @Column(name = "profile_image")
     private String profileImage;
+    @Enumerated(EnumType.STRING)
     private PetType type;
     private LocalDate birth;
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/entity/Pet.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/entity/Pet.java
@@ -1,0 +1,32 @@
+package buddyguard.mybuddyguard.pet.entity;
+
+import buddyguard.mybuddyguard.pet.utils.PetType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "PETS")
+@Getter
+@Builder
+public class Pet {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    @Column(name = "profile_image")
+    private String profileImage;
+    private PetType type;
+    private LocalDate birth;
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/entity/UserPet.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/entity/UserPet.java
@@ -1,0 +1,33 @@
+package buddyguard.mybuddyguard.pet.entity;
+
+import buddyguard.mybuddyguard.pet.utils.UserPetRole;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "USER_PET")
+@Builder
+public class UserPet {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(name = "user_id")
+    @NotNull private Long userId;
+    @Column(name = "pet_id")
+    @NotNull private Long petId;
+    @Enumerated(EnumType.STRING)
+    @NotNull UserPetRole role;
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/entity/UserPet.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/entity/UserPet.java
@@ -1,33 +1,45 @@
 package buddyguard.mybuddyguard.pet.entity;
 
+import buddyguard.mybuddyguard.login.entity.Users;
 import buddyguard.mybuddyguard.pet.utils.UserPetRole;
-import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "USER_PET")
+@Getter
 @Builder
 public class UserPet {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(name = "user_id")
-    @NotNull private Long userId;
-    @Column(name = "pet_id")
-    @NotNull private Long petId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @NotNull
+    private Users user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pet_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @NotNull
+    private Pet pet;
     @Enumerated(EnumType.STRING)
     @NotNull UserPetRole role;
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/mapper/PetMapper.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/mapper/PetMapper.java
@@ -1,0 +1,16 @@
+package buddyguard.mybuddyguard.pet.mapper;
+
+import buddyguard.mybuddyguard.pet.contoller.request.PetRegisterRequest;
+import buddyguard.mybuddyguard.pet.entity.Pet;
+
+public class PetMapper {
+
+    public static Pet toEntity(PetRegisterRequest petRegisterRequest) {
+        return Pet.builder()
+                .name(petRegisterRequest.name())
+                .profileImage(petRegisterRequest.profileImage())
+                .type(petRegisterRequest.type())
+                .birth(petRegisterRequest.birth())
+                .build();
+    }
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/mapper/UserPetMapper.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/mapper/UserPetMapper.java
@@ -1,0 +1,13 @@
+package buddyguard.mybuddyguard.pet.mapper;
+
+import buddyguard.mybuddyguard.login.entity.Users;
+import buddyguard.mybuddyguard.pet.contoller.response.PetWithUserListResponse;
+import buddyguard.mybuddyguard.pet.entity.Pet;
+
+public class UserPetMapper {
+
+    public static PetWithUserListResponse toResponse(Users user, Pet pet) {
+        return new PetWithUserListResponse(user.getId(), pet.getId(), pet.getName(),
+                pet.getProfileImage());
+    }
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/repository/PetRepository.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/repository/PetRepository.java
@@ -1,8 +1,9 @@
 package buddyguard.mybuddyguard.pet.repository;
 
 import buddyguard.mybuddyguard.pet.entity.Pet;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PetRepository extends JpaRepository<Pet, Long> {
-
+    Optional<Pet> findById(Long id);
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/repository/PetRepository.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/repository/PetRepository.java
@@ -1,0 +1,8 @@
+package buddyguard.mybuddyguard.pet.repository;
+
+import buddyguard.mybuddyguard.pet.entity.Pet;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PetRepository extends JpaRepository<Pet, Long> {
+
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/repository/UserPetRepository.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/repository/UserPetRepository.java
@@ -2,6 +2,7 @@ package buddyguard.mybuddyguard.pet.repository;
 
 import buddyguard.mybuddyguard.pet.entity.UserPet;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,4 +14,8 @@ public interface UserPetRepository extends JpaRepository<UserPet, Long> {
     boolean existsByUserExceedPetCount(@Param("userId") Long userId);
 
     List<UserPet> findByUserId(Long userId);
+
+    Optional<UserPet> findByUserIdAndPetId(Long userId, Long petId);
+
+    List<UserPet> getAllByPetId(Long petId);
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/repository/UserPetRepository.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/repository/UserPetRepository.java
@@ -18,4 +18,6 @@ public interface UserPetRepository extends JpaRepository<UserPet, Long> {
     Optional<UserPet> findByUserIdAndPetId(Long userId, Long petId);
 
     List<UserPet> getAllByPetId(Long petId);
+
+    boolean existsByUserIdAndPetId(Long userId, Long petId);
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/repository/UserPetRepository.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/repository/UserPetRepository.java
@@ -1,0 +1,13 @@
+package buddyguard.mybuddyguard.pet.repository;
+
+import buddyguard.mybuddyguard.pet.entity.UserPet;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserPetRepository extends JpaRepository<UserPet, Long> {
+    @Query("SELECT count(*) >= 3 FROM UserPet u where u.userId = :userId")
+    boolean existsByUserExceedPetCount(@Param("userId") Long userId);
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/repository/UserPetRepository.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/repository/UserPetRepository.java
@@ -1,6 +1,7 @@
 package buddyguard.mybuddyguard.pet.repository;
 
 import buddyguard.mybuddyguard.pet.entity.UserPet;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -8,6 +9,8 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserPetRepository extends JpaRepository<UserPet, Long> {
-    @Query("SELECT count(*) >= 3 FROM UserPet u where u.userId = :userId")
+    @Query("SELECT count(*) >= 3 FROM UserPet u where u.id = :userId")
     boolean existsByUserExceedPetCount(@Param("userId") Long userId);
+
+    List<UserPet> findByUserId(Long userId);
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
@@ -1,0 +1,70 @@
+package buddyguard.mybuddyguard.pet.service;
+
+import buddyguard.mybuddyguard.login.repository.UserRepository;
+import buddyguard.mybuddyguard.pet.contoller.request.PetRegisterRequest;
+import buddyguard.mybuddyguard.pet.entity.Pet;
+import buddyguard.mybuddyguard.pet.entity.UserPet;
+import buddyguard.mybuddyguard.pet.mapper.PetMapper;
+import buddyguard.mybuddyguard.pet.repository.PetRepository;
+import buddyguard.mybuddyguard.pet.repository.UserPetRepository;
+import buddyguard.mybuddyguard.pet.utils.UserPetRole;
+import java.util.NoSuchElementException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+public class PetService {
+
+    private final PetRepository repository;
+    private final UserPetRepository userPetRepository;
+    private final UserRepository userRepository;
+
+    public PetService(PetRepository repository, UserPetRepository userPetRepository,
+            UserRepository userRepository) {
+        this.repository = repository;
+        this.userPetRepository = userPetRepository;
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * 펫을 등록한다.
+     * @param petRegisterRequest
+     */
+    @Transactional
+    public void register(PetRegisterRequest petRegisterRequest) {
+        Long userId = petRegisterRequest.userId();
+        if (!validateUser(userId)) {
+            throw new NoSuchElementException();
+        }
+
+        Pet toPet = PetMapper.toEntity(petRegisterRequest);
+        Pet pet = repository.save(toPet);
+
+        // todo : 유저가 게스트인지 호스트인지에 따라 값이 달라져야 함
+        UserPet userPet = UserPet.builder()
+                .userId(userId)
+                .petId(pet.getId())
+                .role(UserPetRole.GUEST).build();
+        userPetRepository.save(userPet);
+
+        log.info("REGISTER PET : {}번 {} 등록", pet.getId(), pet.getName());
+        log.info("REGISTER USER_PET : 사용자 {}에게 {}번 펫 등록", userId, pet.getId());
+    }
+
+    /**
+     * 사용자에게 펫 등록이 가능한지 검증한다.
+     * @param userId
+     * @return
+     */
+    private boolean validateUser(Long userId) {
+        if (!userRepository.existsById(userId)) {
+            return false;
+        }
+        if (userPetRepository.existsByUserExceedPetCount(userId)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
@@ -11,6 +11,9 @@ import buddyguard.mybuddyguard.pet.mapper.UserPetMapper;
 import buddyguard.mybuddyguard.pet.repository.PetRepository;
 import buddyguard.mybuddyguard.pet.repository.UserPetRepository;
 import buddyguard.mybuddyguard.pet.utils.UserPetRole;
+import buddyguard.mybuddyguard.weight.exception.InvalidPetRegisterException;
+import buddyguard.mybuddyguard.weight.exception.PetNotFoundException;
+import buddyguard.mybuddyguard.weight.exception.UserInformationNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -40,9 +43,10 @@ public class PetService {
      */
     @Transactional
     public void register(PetRegisterRequest petRegisterRequest) {
-        Users user = userRepository.findById(petRegisterRequest.userId()).orElseThrow();
+        Users user = userRepository.findById(petRegisterRequest.userId()).orElseThrow(
+                UserInformationNotFoundException::new);
         if (!validateUser(user)) {
-            throw new NoSuchElementException();
+            throw new InvalidPetRegisterException();
         }
 
         Pet toPet = PetMapper.toEntity(petRegisterRequest);
@@ -81,7 +85,8 @@ public class PetService {
      */
     @Transactional
     public void delete(Long userId, Long petId) {
-        UserPet userPetInfo = userPetRepository.findByUserIdAndPetId(userId, petId).orElseThrow();
+        UserPet userPetInfo = userPetRepository.findByUserIdAndPetId(userId, petId)
+                .orElseThrow(UserInformationNotFoundException::new);
         UserPetRole role = userPetInfo.getRole();
 
         userPetRepository.delete(userPetInfo);

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
@@ -50,11 +50,11 @@ public class PetService {
         userPetRepository.save(userPet);
 
         log.info("REGISTER PET : {}번 {} 등록", pet.getId(), pet.getName());
-        log.info("REGISTER USER_PET : 사용자 {}에게 {}번 펫 등록", userId, pet.getId());
+        log.info("REGISTER USER_PET : 유저 {}에게 {}번 펫 등록", userId, pet.getId());
     }
 
     /**
-     * 사용자에게 펫 등록이 가능한지 검증한다.
+     * 유저에게 펫 등록이 가능한지 검증한다.
      * @param userId
      * @return
      */

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
@@ -118,6 +118,8 @@ public class PetService {
                 petUpdateInformationRequest.profileImage(),
                 petUpdateInformationRequest.birth());
 
+        repository.save(pet);
+
         log.info("UPDATE PET : {}번 펫 정보 수정 완료", petId);
     }
 

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
@@ -77,6 +77,13 @@ public class PetService {
         return response;
     }
 
+    public PetWithUserListResponse getOnePetWithUser(Long userId, Long petId) {
+        UserPet userPetInfo = userPetRepository.findByUserIdAndPetId(userId, petId)
+                .orElseThrow(UserInformationNotFoundException::new);
+
+        return UserPetMapper.toResponse(userPetInfo.getUser(), userPetInfo.getPet());
+    }
+
     /**
      * 유저에게 등록된 펫을 삭제한다. 호스트 권한의 유저가 펫을 삭제하는 경우, 게스트 유저들과 해당 펫의 연결도 모두 삭제된다.
      *

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
@@ -3,6 +3,7 @@ package buddyguard.mybuddyguard.pet.service;
 import buddyguard.mybuddyguard.login.entity.Users;
 import buddyguard.mybuddyguard.login.repository.UserRepository;
 import buddyguard.mybuddyguard.pet.contoller.request.PetRegisterRequest;
+import buddyguard.mybuddyguard.pet.contoller.request.PetUpdateInformationRequest;
 import buddyguard.mybuddyguard.pet.contoller.response.PetWithUserListResponse;
 import buddyguard.mybuddyguard.pet.entity.Pet;
 import buddyguard.mybuddyguard.pet.entity.UserPet;
@@ -16,7 +17,6 @@ import buddyguard.mybuddyguard.weight.exception.PetNotFoundException;
 import buddyguard.mybuddyguard.weight.exception.UserInformationNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -97,6 +97,21 @@ public class PetService {
                 userPetRepository.deleteAll(guests);
             }
         }
+    }
+
+    @Transactional
+    public void update(Long userId, Long petId,
+            PetUpdateInformationRequest petUpdateInformationRequest) {
+        if (!userPetRepository.existsByUserIdAndPetId(userId, petId)) {
+            throw new UserInformationNotFoundException();
+        }
+        Pet pet = repository.findById(petId).orElseThrow(PetNotFoundException::new);
+
+        pet.update(petUpdateInformationRequest.name(),
+                petUpdateInformationRequest.profileImage(),
+                petUpdateInformationRequest.birth());
+
+        log.info("UPDATE PET : {}번 펫 정보 수정 완료", petId);
     }
 
     /**

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
@@ -3,9 +3,11 @@ package buddyguard.mybuddyguard.pet.service;
 import buddyguard.mybuddyguard.login.entity.Users;
 import buddyguard.mybuddyguard.login.repository.UserRepository;
 import buddyguard.mybuddyguard.pet.contoller.request.PetRegisterRequest;
+import buddyguard.mybuddyguard.pet.contoller.response.PetWithUserListResponse;
 import buddyguard.mybuddyguard.pet.entity.Pet;
 import buddyguard.mybuddyguard.pet.entity.UserPet;
 import buddyguard.mybuddyguard.pet.mapper.PetMapper;
+import buddyguard.mybuddyguard.pet.mapper.UserPetMapper;
 import buddyguard.mybuddyguard.pet.repository.PetRepository;
 import buddyguard.mybuddyguard.pet.repository.UserPetRepository;
 import buddyguard.mybuddyguard.pet.utils.UserPetRole;
@@ -54,7 +56,21 @@ public class PetService {
         userPetRepository.save(userPet);
 
         log.info("REGISTER PET : {}번 {} 등록", pet.getId(), pet.getName());
-        log.info("REGISTER USER_PET : 유저 {}에게 {}번 펫 등록", userId, pet.getId());
+        log.info("REGISTER USER_PET : 유저 {}에게 {}번 펫 등록", user.getId(), pet.getId());
+    }
+
+    /**
+     * 유저에게 등록되어 있는 펫들을 조회
+     */
+    public List<PetWithUserListResponse> getPetWithUser(Long userId) {
+        List<UserPet> petWithUsers = userPetRepository.findByUserId(userId);
+        List<PetWithUserListResponse> response = new ArrayList<>();
+        for (UserPet userPet : petWithUsers) {
+            Pet pet = userPet.getPet();
+            Users user = userPet.getUser();
+            response.add(UserPetMapper.toResponse(user, pet));
+        }
+        return response;
     }
 
     /**

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
@@ -74,6 +74,27 @@ public class PetService {
     }
 
     /**
+     * 유저에게 등록된 펫을 삭제한다. 호스트 권한의 유저가 펫을 삭제하는 경우, 게스트 유저들과 해당 펫의 연결도 모두 삭제된다.
+     *
+     * @param userId
+     * @param petId
+     */
+    @Transactional
+    public void delete(Long userId, Long petId) {
+        UserPet userPetInfo = userPetRepository.findByUserIdAndPetId(userId, petId).orElseThrow();
+        UserPetRole role = userPetInfo.getRole();
+
+        userPetRepository.delete(userPetInfo);
+
+        if (role.equals(UserPetRole.HOST)) {
+            List<UserPet> guests = userPetRepository.getAllByPetId(petId);
+            if (!guests.isEmpty()) {
+                userPetRepository.deleteAll(guests);
+            }
+        }
+    }
+
+    /**
      * 유저에게 펫 등록이 가능한지 검증한다.
      *
      * @param user

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/utils/PetType.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/utils/PetType.java
@@ -1,0 +1,6 @@
+package buddyguard.mybuddyguard.pet.utils;
+
+public enum PetType {
+    CAT,
+    DOG
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/utils/UserPetRole.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/utils/UserPetRole.java
@@ -1,0 +1,6 @@
+package buddyguard.mybuddyguard.pet.utils;
+
+public enum UserPetRole {
+    HOST,
+    GUEST;
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/weight/exception/InvalidPetRegisterException.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/weight/exception/InvalidPetRegisterException.java
@@ -1,0 +1,11 @@
+package buddyguard.mybuddyguard.weight.exception;
+
+import buddyguard.mybuddyguard.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidPetRegisterException extends BusinessException {
+
+    public InvalidPetRegisterException() {
+        super(HttpStatus.BAD_REQUEST, "펫을 등록할 수 없습니다.");
+    }
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/weight/exception/PetNotFoundException.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/weight/exception/PetNotFoundException.java
@@ -1,0 +1,12 @@
+package buddyguard.mybuddyguard.weight.exception;
+
+import buddyguard.mybuddyguard.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class PetNotFoundException extends BusinessException {
+
+    public PetNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "관련된 펫의 정보가 존재하지 않습니다.");
+    }
+}
+

--- a/be/src/main/java/buddyguard/mybuddyguard/weight/exception/UserInformationNotFoundException.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/weight/exception/UserInformationNotFoundException.java
@@ -1,0 +1,11 @@
+package buddyguard.mybuddyguard.weight.exception;
+
+import buddyguard.mybuddyguard.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class UserInformationNotFoundException extends BusinessException {
+
+    public UserInformationNotFoundException() {
+        super(HttpStatus.NOT_FOUND, "관련된 유저의 정보가 존재하지 않습니다.");
+    }
+}

--- a/be/src/test/java/buddyguard/mybuddyguard/pet/service/PetServiceTest.java
+++ b/be/src/test/java/buddyguard/mybuddyguard/pet/service/PetServiceTest.java
@@ -1,0 +1,319 @@
+package buddyguard.mybuddyguard.pet.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import buddyguard.mybuddyguard.login.entity.Users;
+import buddyguard.mybuddyguard.login.repository.UserRepository;
+import buddyguard.mybuddyguard.pet.contoller.request.PetRegisterRequest;
+import buddyguard.mybuddyguard.pet.contoller.request.PetUpdateInformationRequest;
+import buddyguard.mybuddyguard.pet.contoller.response.PetWithUserListResponse;
+import buddyguard.mybuddyguard.pet.entity.Pet;
+import buddyguard.mybuddyguard.pet.entity.UserPet;
+import buddyguard.mybuddyguard.pet.mapper.PetMapper;
+import buddyguard.mybuddyguard.pet.repository.PetRepository;
+import buddyguard.mybuddyguard.pet.repository.UserPetRepository;
+import buddyguard.mybuddyguard.pet.utils.PetType;
+import buddyguard.mybuddyguard.pet.utils.UserPetRole;
+import buddyguard.mybuddyguard.weight.exception.InvalidPetRegisterException;
+import buddyguard.mybuddyguard.weight.exception.PetNotFoundException;
+import buddyguard.mybuddyguard.weight.exception.UserInformationNotFoundException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PetServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PetRepository petRepository;
+
+    @Mock
+    private UserPetRepository userPetRepository;
+
+    @InjectMocks
+    private PetService petService;
+
+    private Users user;
+
+    private Pet pet;
+
+    @BeforeEach
+    void 유저와_펫_생성() {
+        user = new Users();
+        user.setId(1L);
+        user.setName("tester");
+
+        pet = Pet.builder().id(1L).build();
+    }
+
+    @Test
+    void 정상적으로_펫_등록() {
+        // GIVEN
+        PetRegisterRequest petRegisterRequest = new PetRegisterRequest(user.getId(), "toto",
+                "www.naver.com", PetType.DOG, LocalDate.now());
+
+        Pet insertPet = Pet.builder().id(1L).birth(petRegisterRequest.birth())
+                .type(petRegisterRequest.type()).profileImage(petRegisterRequest.profileImage())
+                .name(petRegisterRequest.name()).build();
+
+        UserPet userPet = UserPet.builder().id(1L).user(user).pet(insertPet).role(
+                UserPetRole.HOST).build();
+
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(petRepository.save(any(Pet.class))).thenReturn(insertPet);
+        when(userPetRepository.save(any(UserPet.class))).thenReturn(userPet);
+
+        // WHEN
+        petService.register(petRegisterRequest);
+
+        // THEN
+        verify(petRepository).save(any(Pet.class));
+        verify(userPetRepository).save(any(UserPet.class));
+    }
+
+    @Test
+    void 펫_3마리_이상_유저_펫_등록시_예외_발생() {
+        // GIVEN
+        PetRegisterRequest petRegisterRequest = new PetRegisterRequest(user.getId(), "toto",
+                "www.naver.com", PetType.DOG, LocalDate.now());
+
+        Pet insertPet = Pet.builder().id(1L).birth(petRegisterRequest.birth())
+                .type(petRegisterRequest.type()).profileImage(petRegisterRequest.profileImage())
+                .name(petRegisterRequest.name()).build();
+
+        when(userRepository.findById(user.getId())).thenReturn(Optional.of(user));
+        when(userPetRepository.existsByUserExceedPetCount(user.getId())).thenReturn(true);
+
+        // WHEN, THEN
+        assertThatThrownBy(() -> petService.register(petRegisterRequest)).isInstanceOf(
+                InvalidPetRegisterException.class);
+
+    }
+
+    @Test
+    void 유저가_존재하지_않는_경우_펫_등록시_예외_발생() {
+        // GIVEN
+        PetRegisterRequest petRegisterRequest = new PetRegisterRequest(user.getId(), "toto",
+                "www.naver.com", PetType.DOG, LocalDate.now());
+
+        Pet insertPet = Pet.builder().id(1L).birth(petRegisterRequest.birth())
+                .type(petRegisterRequest.type()).profileImage(petRegisterRequest.profileImage())
+                .name(petRegisterRequest.name()).build();
+
+        when(userRepository.findById(user.getId())).thenReturn(Optional.empty());
+
+        // WHEN, THEN
+        assertThatThrownBy(() -> petService.register(petRegisterRequest)).isInstanceOf(
+                UserInformationNotFoundException.class);
+
+    }
+
+    @Test
+    void 특정_유저의_펫_전체리스트_정상_조회() {
+        // GIVEN
+        Pet pet2 = Pet.builder().id(2L).build();
+
+        UserPet userPet = UserPet.builder().id(1L).user(user).pet(pet).role(
+                UserPetRole.HOST).build();
+        UserPet userPet2 = UserPet.builder().id(2L).user(user).pet(pet2).role(
+                UserPetRole.HOST).build();
+        List<UserPet> list = new ArrayList<>();
+        list.add(userPet);
+        list.add(userPet2);
+
+        when(userPetRepository.findByUserId(user.getId())).thenReturn(list);
+
+        // WHEN
+        List<PetWithUserListResponse> result = petService.getPetWithUser(user.getId());
+
+        // THEN
+        assertThat(result).isNotNull().hasSize(2);
+        assertThat(result.get(0).petId()).isEqualTo(1L);
+        assertThat(result.get(0).userId()).isEqualTo(1L);
+
+        assertThat(result.get(1).petId()).isEqualTo(2L);
+        assertThat(result.get(1).userId()).isEqualTo(1L);
+    }
+
+    @Test
+    void 특정_유저의_펫_전체리스트_조회시_정보가_존재하지_않는_경우() {
+        // GIVEN
+        List<UserPet> list = new ArrayList<>();
+
+        when(userPetRepository.findByUserId(user.getId())).thenReturn(list);
+
+        // WHEN
+        List<PetWithUserListResponse> result = petService.getPetWithUser(user.getId());
+
+        // THEN
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void 특정_유저의_단일_펫_정상_조회() {
+        // GIVEN
+        Pet pet2 = Pet.builder().id(2L).build();
+
+        UserPet userPet = UserPet.builder().id(1L).user(user).pet(pet).role(
+                UserPetRole.HOST).build();
+        UserPet userPet2 = UserPet.builder().id(2L).user(user).pet(pet2).role(
+                UserPetRole.HOST).build();
+        List<UserPet> list = new ArrayList<>();
+        list.add(userPet);
+        list.add(userPet2);
+
+        when(userPetRepository.findByUserIdAndPetId(user.getId(), pet2.getId())).thenReturn(
+                Optional.of(userPet2));
+
+        // WHEN
+        PetWithUserListResponse result = petService.getOnePetWithUser(user.getId(), pet2.getId());
+
+        // THEN
+        assertThat(result.petId()).isEqualTo(2L);
+    }
+
+    @Test
+    void 특정_유저의_단일_펫_조회시_정보가_존재하지_않는_경우() {
+        // GIVEN
+        when(userPetRepository.findByUserIdAndPetId(user.getId(), 3L)).thenReturn(Optional.empty());
+
+        // WHEN, THEN
+        assertThatThrownBy(() -> petService.getOnePetWithUser(user.getId(), 3L))
+                .isInstanceOf(UserInformationNotFoundException.class);
+    }
+
+    @Test
+    void 호스트_유저의_펫_정상_삭제() {
+        // GIVEN
+        Users user2 = new Users();
+        user2.setId(2L);
+
+        List<UserPet> guests = new ArrayList<>();
+        UserPet userPet = UserPet.builder().id(1L).user(user).pet(pet).role(
+                UserPetRole.HOST).build();
+        UserPet userPet2 = UserPet.builder().id(2L).user(user2).pet(pet).role(
+                UserPetRole.GUEST).build();
+        guests.add(userPet2);
+
+        when(userPetRepository.findByUserIdAndPetId(user.getId(), pet.getId())).thenReturn(
+                Optional.of(userPet));
+        when(userPetRepository.getAllByPetId(pet.getId())).thenReturn(guests);
+
+        // WHEN
+        petService.delete(user.getId(), pet.getId());
+
+        // THEN
+        verify(userPetRepository).delete(userPet);
+        verify(userPetRepository).findByUserIdAndPetId(user.getId(), pet.getId());
+        verify(userPetRepository).deleteAll(guests);
+    }
+
+    @Test
+    void 게스트_유저의_펫_정상_삭제() {
+        // GIVEN
+        Users guest = new Users();
+        guest.setId(2L);
+
+        UserPet hostInfo = UserPet.builder().id(1L).user(user).pet(pet).role(
+                UserPetRole.HOST).build();
+        UserPet guestInfo = UserPet.builder().id(2L).user(guest).pet(pet).role(
+                UserPetRole.GUEST).build();
+
+        when(userPetRepository.findByUserIdAndPetId(guest.getId(), pet.getId())).thenReturn(
+                Optional.of(guestInfo));
+        when(userPetRepository.findByUserIdAndPetId(user.getId(), pet.getId())).thenReturn(
+                Optional.of(hostInfo));
+
+        // WHEN
+        petService.delete(guest.getId(), pet.getId());
+
+        // THEN
+        verify(userPetRepository).delete(guestInfo);
+        Optional<UserPet> hostResult = userPetRepository.findByUserIdAndPetId(user.getId(),
+                pet.getId());
+        assertThat(hostResult).isPresent();
+        assertThat(hostResult.get().getRole()).isEqualTo(UserPetRole.HOST);
+    }
+
+    @Test
+    void 정보가_없는_경우_펫_삭제시_예외_발생() {
+        // GIVEN
+        when(userPetRepository.findByUserIdAndPetId(user.getId(), pet.getId())).thenReturn(
+                Optional.empty());
+
+        // WHEN, THEN
+        assertThatThrownBy(() -> petService.delete(user.getId(), pet.getId())).isInstanceOf(
+                UserInformationNotFoundException.class);
+
+    }
+
+    @Test
+    void 펫_정보_정상_수정() {
+        // GIVEN
+        PetUpdateInformationRequest updateInformationRequest = new PetUpdateInformationRequest(
+                "new name", "www.example.com", LocalDate.now());
+
+        when(userPetRepository.existsByUserIdAndPetId(user.getId(), pet.getId())).thenReturn(true);
+        when(petRepository.findById(pet.getId())).thenReturn(Optional.of(pet));
+        doAnswer(invocation -> {
+            Pet afterPet = invocation.getArgument(0);
+            afterPet.update(updateInformationRequest.name(),
+                    updateInformationRequest.profileImage(), null);
+            return afterPet;
+        }).when(petRepository).save(pet);
+
+        // WHEN
+        petService.update(user.getId(), pet.getId(), updateInformationRequest);
+
+        // THEN
+        verify(petRepository).save(pet);
+        assertThat(pet.getName()).isEqualTo(updateInformationRequest.name());
+        assertThat(pet.getProfileImage()).isEqualTo(updateInformationRequest.profileImage());
+
+    }
+
+    @Test
+    void 정보가_없는_경우_펫_정보_수정_시_예외_발생() {
+        // GIVEN
+        PetUpdateInformationRequest updateInformationRequest = new PetUpdateInformationRequest(
+                "new name", "www.example.com", LocalDate.now());
+
+        when(userPetRepository.existsByUserIdAndPetId(user.getId(), pet.getId())).thenThrow(
+                UserInformationNotFoundException.class);
+
+        // WHEN, THEN
+        assertThatThrownBy(() -> petService.update(user.getId(), pet.getId(),
+                updateInformationRequest)).isInstanceOf(UserInformationNotFoundException.class);
+
+    }
+
+    @Test
+    void 펫_정보가_없는_경우_펫_정보_수정_시_예외_발생() {
+        // GIVEN
+        PetUpdateInformationRequest updateInformationRequest = new PetUpdateInformationRequest(
+                "new name", "www.example.com", LocalDate.now());
+
+        when(userPetRepository.existsByUserIdAndPetId(user.getId(), pet.getId())).thenReturn(true);
+        when(petRepository.findById(pet.getId())).thenReturn(Optional.empty());
+
+        // WHEN, THEN
+        assertThatThrownBy(() -> petService.update(user.getId(), pet.getId(),
+                updateInformationRequest)).isInstanceOf(PetNotFoundException.class);
+
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Closes #33 

## 📝 작업 내용
- 펫 등록, 수정, 삭제, 조회 기능을 구현했습니다.

## ✍️ 전달 사항
- 펫 등록 부분은 추후 호스트 / 게스트 유저와 초대 기능을 구현한 후 수정이 필요한 부분입니다. 금주 내로 완료할 수 있도록 목표하고 있습니다.

## 💬 리뷰 요구사항(선택)
- 심바와 진이 작성하신 기본 CRUD 방식과 스타일을 맞추려 시도를 해봤는데 더 수정할 점이 있을지 한 번 확인 부탁드립니다
