### PR TITLE
[fix] 로그인 후 쿠키에 토큰 담기 & 프론트 메인으로 리다이렉션

### DIFF
--- a/be/src/main/java/buddyguard/mybuddyguard/config/SecurityConfig.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/config/SecurityConfig.java
@@ -69,6 +69,8 @@ public class SecurityConfig {
         http.addFilterBefore(new CustomLogoutFilter(tokenService, repository, entryPoint),
                 LogoutFilter.class);
 
+        http.oauth2Login(oauth2 -> oauth2.loginPage("/oauth2/authorization/kakao"));
+
         http.cors(httpSecurityCorsConfigurer -> httpSecurityCorsConfigurer.configurationSource(
                 new CorsConfigurationSource() {
                     @Override

--- a/be/src/main/java/buddyguard/mybuddyguard/login/handler/CustomSuccessHandler.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/login/handler/CustomSuccessHandler.java
@@ -56,15 +56,10 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         // refresh 토큰 저장
         saveRefreshToken(userId, refreshToken, 7 * 24 * 60 * 60L);
 
-        // body에 토큰 저장
-        Map<String, String> bodyMap = new HashMap<>();
-        bodyMap.put("refresh", refreshToken);
-        bodyMap.put("access", accessToken);
-
-        ObjectMapper mapper = new ObjectMapper();
-        String body = mapper.writeValueAsString(bodyMap);
-
-        response.getWriter().write(body);
+        // 쿠키에 토큰 저장
+        response.addCookie(createCookie("access", accessToken));
+        response.addCookie(createCookie("refresh", refreshToken));
+        response.sendRedirect("http://localhost:5713/");
     }
 
     /**


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#57 

## 📝 작업 내용

- 토큰 생성 후 전달 방식 바디에서 쿠키로 변경
- 프론트 메인 화면으로 리다이렉션 시키도록 변경
- /login 요청 시 바로 카카오 로그인 창이 뜨도록 변경
