### PR TITLE
refactor: 존재하지 않는 펫 id로 전체 체중기록 조회시 예외 발생하도록 추가

### DIFF
--- a/be/src/main/java/buddyguard/mybuddyguard/weight/service/WeightService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/weight/service/WeightService.java
@@ -33,6 +33,10 @@ public class WeightService {
 
         List<Weight> weights = weightRepository.findAllByPetId(petId);
 
+        if (weights.isEmpty()) {
+            throw new RecordNotFoundException();
+        }
+
         return WeightMapper.toResponseList(weights);
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#8 

## 📝 작업 내용

존재하지 않는 펫 id로 전체 체중기록 조회시 예외 발생하도록 추가