### PR TITLE
[fix] 유저 아이디 추출 방법 변경 & 예외 및 로직 일부 수정

### DIFF
--- a/be/src/main/java/buddyguard/mybuddyguard/exception/AlreadyInGroupException.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/exception/AlreadyInGroupException.java
@@ -1,0 +1,10 @@
+package buddyguard.mybuddyguard.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class AlreadyInGroupException extends BusinessException{
+
+    public AlreadyInGroupException() {
+        super(HttpStatus.BAD_REQUEST, "이미 참여중인 그룹입니다.");
+    }
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/exception/UserPetGroupException.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/exception/UserPetGroupException.java
@@ -1,0 +1,10 @@
+package buddyguard.mybuddyguard.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UserPetGroupException extends BusinessException{
+
+    public UserPetGroupException() {
+        super(HttpStatus.NOT_FOUND, "해당 유저와 펫 그룹은 존재하지 않습니다.");
+    }
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/invitation/controller/InvitationController.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/invitation/controller/InvitationController.java
@@ -2,10 +2,16 @@ package buddyguard.mybuddyguard.invitation.controller;
 
 import buddyguard.mybuddyguard.invitation.controller.response.InvitationLinkResponse;
 import buddyguard.mybuddyguard.invitation.service.InvitationService;
+import buddyguard.mybuddyguard.login.dto.CustomOAuth2User;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,9 +28,11 @@ public class InvitationController {
     }
 
     @Operation(summary = "초대 링크를 생성하는 api", description = "펫 id를 이용해서 사용자-펫 그룹 게스트 초대를 위한 초대 링크를 생성합니다")
-    @GetMapping("/{userId}/{petId}")
+    @GetMapping("/link/{petId}")
     public ResponseEntity<InvitationLinkResponse> makeInvitationLink(
-            @PathVariable("userId") Long userId, @PathVariable("petId") Long petId) {
+            @PathVariable("petId") Long petId,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        Long userId = customOAuth2User.getId();
         InvitationLinkResponse response = invitationService.makeInvitationLink(userId, petId);
         return ResponseEntity.ok(response);
     }
@@ -32,9 +40,9 @@ public class InvitationController {
     @Operation(summary = "초대 링크를 통해 그룹에 가입하는 api", description = "초대 링크를 통해 유저는 기존 사용자-펫 그룹에 게스트로 가입합니다")
     @GetMapping("/{uuid}")
     public ResponseEntity<Void> registerInvitation(@PathVariable("uuid") String uuid,
-            HttpServletRequest request) {
-        String token = request.getHeader("Authorization");
-        invitationService.register(uuid, token);
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        Long userId = customOAuth2User.getId();
+        invitationService.register(uuid, userId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/invitation/service/InvitationService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/invitation/service/InvitationService.java
@@ -95,7 +95,7 @@ public class InvitationService {
             throw new UserPetGroupNotFound();
         }
         if (userPetRepository.findByUserIdAndPetId(userId, petId).isPresent()) {
-            throw new InvalidPetRegisterException();
+            throw new AlreadyInGroupException();
         }
     }
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/PetController.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/PetController.java
@@ -1,5 +1,6 @@
 package buddyguard.mybuddyguard.pet.contoller;
 
+import buddyguard.mybuddyguard.login.dto.CustomOAuth2User;
 import buddyguard.mybuddyguard.pet.contoller.request.PetRegisterRequest;
 import buddyguard.mybuddyguard.pet.contoller.request.PetUpdateInformationRequest;
 import buddyguard.mybuddyguard.pet.contoller.response.PetWithUserListResponse;
@@ -9,6 +10,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -27,42 +29,49 @@ public class PetController {
 
     @Operation(summary = "펫을 등록하는 api", description = "유저에게 새로운 펫을 등록합니다")
     @PostMapping
-    public ResponseEntity<Void> registerPet(@RequestBody PetRegisterRequest petRegisterRequest) {
-        service.register(petRegisterRequest);
+    public ResponseEntity<Void> registerPet(@RequestBody PetRegisterRequest petRegisterRequest,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        Long userId = customOAuth2User.getId();
+        service.register(petRegisterRequest, userId);
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
     @Operation(summary = "유저의 모든 펫 정보를 가져오는 api", description = "유저와 연결된 모든 펫(최대 3마리) 리스트를 조회합니다")
-    @GetMapping("/{userId}")
+    @GetMapping()
     public ResponseEntity<List<PetWithUserListResponse>> getPetWithUser(
-            @PathVariable("userId") Long userId) {
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        Long userId = customOAuth2User.getId();
         List<PetWithUserListResponse> response = service.getPetWithUser(userId);
 
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "펫 한 마리의 정보를 가져오는 api", description = "유저의 펫들 중에서 1마리의 정보만을 조회합니다")
-    @GetMapping("/{userId}/{petId}")
+    @GetMapping("/{petId}")
     public ResponseEntity<PetWithUserListResponse> getOnePetWithUser(
-            @PathVariable("userId") Long userId, @PathVariable("petId") Long petId) {
+            @PathVariable("petId") Long petId,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        Long userId = customOAuth2User.getId();
         PetWithUserListResponse response = service.getOnePetWithUser(userId, petId);
 
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "펫을 삭제하는 api", description = "유저가 등록한 펫의 정보를 삭제합니다. 호스트 유저가 펫을 삭제하는 경우, 게스트 유저들과 해당 펫의 연결도 모두 삭제됩니다")
-    @DeleteMapping("/{userId}/{petId}")
-    public ResponseEntity<Void> deletePet(@PathVariable("userId") Long userId,
-            @PathVariable("petId") Long petId) {
+    @DeleteMapping("/{petId}")
+    public ResponseEntity<Void> deletePet(@PathVariable("petId") Long petId,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        Long userId = customOAuth2User.getId();
         service.delete(userId, petId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @Operation(summary = "유저의 펫의 정보를 업데이트하는 api", description = "유저와 연결된 펫 중 한마리의 정보를 업데이트합니다")
-    @PatchMapping("/{userId}/{petId}")
-    public ResponseEntity<Void> updatePetInformation(@PathVariable("userId") Long userId,
-            @PathVariable("petId") Long petId,
-            @RequestBody PetUpdateInformationRequest petUpdateInformationRequest) {
+    @PatchMapping("/{petId}")
+    public ResponseEntity<Void> updatePetInformation(@PathVariable("petId") Long petId,
+            @RequestBody PetUpdateInformationRequest petUpdateInformationRequest,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        Long userId = customOAuth2User.getId();
         service.update(userId, petId, petUpdateInformationRequest);
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/request/PetRegisterRequest.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/request/PetRegisterRequest.java
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 public record PetRegisterRequest(
-        @JsonProperty("user_id") @NotNull Long userId,
         @NotNull String name,
         @JsonProperty("profile_image") @NotNull String profileImage,
         @NotNull PetType type,

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/exception/InvalidPetRegisterException.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/exception/InvalidPetRegisterException.java
@@ -6,6 +6,6 @@ import org.springframework.http.HttpStatus;
 public class InvalidPetRegisterException extends BusinessException {
 
     public InvalidPetRegisterException() {
-        super(HttpStatus.BAD_REQUEST, "펫을 등록할 수 없습니다.");
+        super(HttpStatus.BAD_REQUEST, "펫은 3마리 이상 등록할 수 없습니다.");
     }
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/repository/UserPetRepository.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/repository/UserPetRepository.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserPetRepository extends JpaRepository<UserPet, Long> {
-    @Query("SELECT count(*) >= 3 FROM UserPet u where u.id = :userId")
+    @Query("SELECT CASE WHEN COUNT(u) >= 3 THEN TRUE ELSE FALSE END FROM UserPet u WHERE u.user.id = :userId")
     boolean existsByUserExceedPetCount(@Param("userId") Long userId);
 
     List<UserPet> findByUserId(Long userId);

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
@@ -40,10 +40,11 @@ public class PetService {
      * 펫을 등록한다.
      *
      * @param petRegisterRequest
+     * @param userId
      */
     @Transactional
-    public void register(PetRegisterRequest petRegisterRequest) {
-        Users user = userRepository.findById(petRegisterRequest.userId()).orElseThrow(
+    public void register(PetRegisterRequest petRegisterRequest, Long userId) {
+        Users user = userRepository.findById(userId).orElseThrow(
                 UserInformationNotFoundException::new);
         if (!validateUser(user)) {
             throw new InvalidPetRegisterException();

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
@@ -100,6 +100,7 @@ public class PetService {
         userPetRepository.delete(userPetInfo);
 
         if (role.equals(UserPetRole.HOST)) {
+            repository.deleteById(petId);
             List<UserPet> guests = userPetRepository.getAllByPetId(petId);
             if (!guests.isEmpty()) {
                 userPetRepository.deleteAll(guests);

--- a/be/src/test/java/buddyguard/mybuddyguard/pet/service/PetServiceTest.java
+++ b/be/src/test/java/buddyguard/mybuddyguard/pet/service/PetServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import buddyguard.mybuddyguard.exception.PetNotFoundException;
 import buddyguard.mybuddyguard.exception.UserInformationNotFoundException;
+import buddyguard.mybuddyguard.exception.UserPetGroupException;
 import buddyguard.mybuddyguard.login.entity.Users;
 import buddyguard.mybuddyguard.login.repository.UserRepository;
 import buddyguard.mybuddyguard.pet.contoller.request.PetRegisterRequest;
@@ -63,7 +64,7 @@ public class PetServiceTest {
     @Test
     void 정상적으로_펫_등록() {
         // GIVEN
-        PetRegisterRequest petRegisterRequest = new PetRegisterRequest(user.getId(), "toto",
+        PetRegisterRequest petRegisterRequest = new PetRegisterRequest("toto",
                 "www.naver.com", PetType.DOG, LocalDate.now());
 
         Pet insertPet = Pet.builder().id(1L).birth(petRegisterRequest.birth())
@@ -78,7 +79,7 @@ public class PetServiceTest {
         when(userPetRepository.save(any(UserPet.class))).thenReturn(userPet);
 
         // WHEN
-        petService.register(petRegisterRequest);
+        petService.register(petRegisterRequest, user.getId());
 
         // THEN
         verify(petRepository).save(any(Pet.class));
@@ -88,7 +89,7 @@ public class PetServiceTest {
     @Test
     void 펫_3마리_이상_유저_펫_등록시_예외_발생() {
         // GIVEN
-        PetRegisterRequest petRegisterRequest = new PetRegisterRequest(user.getId(), "toto",
+        PetRegisterRequest petRegisterRequest = new PetRegisterRequest("toto",
                 "www.naver.com", PetType.DOG, LocalDate.now());
 
         Pet insertPet = Pet.builder().id(1L).birth(petRegisterRequest.birth())
@@ -99,7 +100,7 @@ public class PetServiceTest {
         when(userPetRepository.existsByUserExceedPetCount(user.getId())).thenReturn(true);
 
         // WHEN, THEN
-        assertThatThrownBy(() -> petService.register(petRegisterRequest)).isInstanceOf(
+        assertThatThrownBy(() -> petService.register(petRegisterRequest, user.getId())).isInstanceOf(
                 InvalidPetRegisterException.class);
 
     }
@@ -107,7 +108,7 @@ public class PetServiceTest {
     @Test
     void 유저가_존재하지_않는_경우_펫_등록시_예외_발생() {
         // GIVEN
-        PetRegisterRequest petRegisterRequest = new PetRegisterRequest(user.getId(), "toto",
+        PetRegisterRequest petRegisterRequest = new PetRegisterRequest("toto",
                 "www.naver.com", PetType.DOG, LocalDate.now());
 
         Pet insertPet = Pet.builder().id(1L).birth(petRegisterRequest.birth())
@@ -117,7 +118,7 @@ public class PetServiceTest {
         when(userRepository.findById(user.getId())).thenReturn(Optional.empty());
 
         // WHEN, THEN
-        assertThatThrownBy(() -> petService.register(petRegisterRequest)).isInstanceOf(
+        assertThatThrownBy(() -> petService.register(petRegisterRequest, user.getId())).isInstanceOf(
                 UserInformationNotFoundException.class);
 
     }
@@ -193,7 +194,7 @@ public class PetServiceTest {
 
         // WHEN, THEN
         assertThatThrownBy(() -> petService.getOnePetWithUser(user.getId(), 3L))
-                .isInstanceOf(UserInformationNotFoundException.class);
+                .isInstanceOf(UserPetGroupException.class);
     }
 
     @Test
@@ -257,7 +258,7 @@ public class PetServiceTest {
 
         // WHEN, THEN
         assertThatThrownBy(() -> petService.delete(user.getId(), pet.getId())).isInstanceOf(
-                UserInformationNotFoundException.class);
+                UserPetGroupException.class);
 
     }
 
@@ -293,11 +294,11 @@ public class PetServiceTest {
                 "new name", "www.example.com", LocalDate.now());
 
         when(userPetRepository.existsByUserIdAndPetId(user.getId(), pet.getId())).thenThrow(
-                UserInformationNotFoundException.class);
+                UserPetGroupException.class);
 
         // WHEN, THEN
         assertThatThrownBy(() -> petService.update(user.getId(), pet.getId(),
-                updateInformationRequest)).isInstanceOf(UserInformationNotFoundException.class);
+                updateInformationRequest)).isInstanceOf(UserPetGroupException.class);
 
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

 #94 
#91 

## 📝 작업 내용

- 유저 아이디를 경로 매개변수에서, SecurityContextHolder 내부 Authentication 를 활용하여 추출하도록 변경했습니다.
- 펫과 초대링크 서비스에서 예외가 발생하는 조건이 다른데, 예외 메시지가 동일하게 출력되고 있어서 이를 나눠서 출력하도록 예외를 추가했습니다.