### PR TITLE
[feat] 회원 유저 정보 조회 기능 구현

### DIFF
--- a/be/src/main/java/buddyguard/mybuddyguard/login/controller/UserController.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/login/controller/UserController.java
@@ -1,0 +1,27 @@
+package buddyguard.mybuddyguard.login.controller;
+
+import buddyguard.mybuddyguard.login.controller.response.UserInformationResponse;
+import buddyguard.mybuddyguard.login.dto.CustomOAuth2User;
+import buddyguard.mybuddyguard.login.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/user")
+    public ResponseEntity<UserInformationResponse> getUserInformation(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        Long userId = customOAuth2User.getId();
+        UserInformationResponse result = userService.getUserInformation(userId);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/login/controller/response/UserInformationResponse.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/login/controller/response/UserInformationResponse.java
@@ -1,0 +1,8 @@
+package buddyguard.mybuddyguard.login.controller.response;
+
+import java.util.List;
+
+public record UserInformationResponse(Long userId, String name, String email, String profileImage,
+                                      List<Long> petsId) {
+
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/login/service/UserService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/login/service/UserService.java
@@ -1,0 +1,38 @@
+package buddyguard.mybuddyguard.login.service;
+
+
+import buddyguard.mybuddyguard.exception.UserInformationNotFoundException;
+import buddyguard.mybuddyguard.login.controller.response.UserInformationResponse;
+import buddyguard.mybuddyguard.login.entity.Users;
+import buddyguard.mybuddyguard.login.repository.UserRepository;
+import buddyguard.mybuddyguard.pet.entity.UserPet;
+import buddyguard.mybuddyguard.pet.repository.UserPetRepository;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final UserPetRepository userPetRepository;
+
+    public UserService(UserRepository userRepository, UserPetRepository userPetRepository) {
+        this.userRepository = userRepository;
+        this.userPetRepository = userPetRepository;
+    }
+
+    public UserInformationResponse getUserInformation(Long userId) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(UserInformationNotFoundException::new);
+
+        List<UserPet> petWithUsers = userPetRepository.findByUserId(userId);
+        List<Long> petsId = new ArrayList<>();
+        for (UserPet userPet : petWithUsers) {
+            petsId.add(userPet.getPet().getId());
+        }
+
+        return new UserInformationResponse(userId, user.getName(), user.getEmail(),
+                user.getProfileImage(), petsId);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closes #96

## 📝 작업 내용

- 회원 정보 조회 시, 회원 아이디, 이름, 사진, 프로필, 펫 아이디 리스트를 반환하는 api를 구현했습니다.
