### PR TITLE
[feat] swagger api 설명 추가

### DIFF
--- a/be/src/main/java/buddyguard/mybuddyguard/login/controller/UserController.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/login/controller/UserController.java
@@ -3,6 +3,7 @@ package buddyguard.mybuddyguard.login.controller;
 import buddyguard.mybuddyguard.login.controller.response.UserInformationResponse;
 import buddyguard.mybuddyguard.login.dto.CustomOAuth2User;
 import buddyguard.mybuddyguard.login.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +18,7 @@ public class UserController {
         this.userService = userService;
     }
 
+    @Operation(summary = "로그인 한 유저의 정보를 가져오는 api", description = "유저 이름, 이메일, 프로필 사진, 펫들 아이디를 포함한 정보를 가져옵니다.")
     @GetMapping("/user")
     public ResponseEntity<UserInformationResponse> getUserInformation(
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {

--- a/be/src/main/java/buddyguard/mybuddyguard/schedule/controller/ScheduleController.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/schedule/controller/ScheduleController.java
@@ -2,6 +2,7 @@ package buddyguard.mybuddyguard.schedule.controller;
 
 import buddyguard.mybuddyguard.schedule.controller.response.ScheduleMonthlyResponse;
 import buddyguard.mybuddyguard.schedule.service.ScheduleService;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +18,7 @@ public class ScheduleController {
         this.scheduleService = scheduleService;
     }
 
+    @Operation(summary = "펫의 달별 기록을 가져오는 api", description = "특정 펫의 특정 달의 기록을 가져옵니다. 해당 펫이 존재하지 않거나, 펫 그룹에 로그인 유저가 속하지 않을 경우 예외가 발생합니다.")
     @GetMapping("/schedule/{petId}/{year}/{month}")
     public ResponseEntity<ScheduleMonthlyResponse> getMonthlySchedule(
             @PathVariable("petId") Long petId,


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#88 

## 📝 작업 내용

- swagger에서의 일정조회 api와 유저정보 조회 api 의 상세 설명을 추가했습니다.