### PR TITLE
[refactor] refresh 토큰 저장 DB Redis로 변경

### DIFF
--- a/be/src/main/java/buddyguard/mybuddyguard/config/RedisConfig.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/config/RedisConfig.java
@@ -14,9 +14,10 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
 
 @EnableJpaRepositories(basePackages = {"buddyguard.mybuddyguard.hospital",
         "buddyguard.mybuddyguard.login", "buddyguard.mybuddyguard.pet",
-        "buddyguard.mybuddyguard.weight", "buddyguard.mybuddyguard.jwt",
-        "buddyguard.mybuddyguard.walk", "buddyguard.mybuddyguard.alert"})
-@EnableRedisRepositories(basePackages = "buddyguard.mybuddyguard.invitation.repository")
+        "buddyguard.mybuddyguard.weight", "buddyguard.mybuddyguard.walk",
+        "buddyguard.mybuddyguard.alert"})
+@EnableRedisRepositories(basePackages = {"buddyguard.mybuddyguard.invitation",
+        "buddyguard.mybuddyguard.jwt"})
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")

--- a/be/src/main/java/buddyguard/mybuddyguard/jwt/entity/RefreshToken.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/jwt/entity/RefreshToken.java
@@ -1,24 +1,21 @@
 package buddyguard.mybuddyguard.jwt.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
 
-@Entity
+@RedisHash(value = "refresh", timeToLive = 7 * 24 * 60 * 60L)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Getter
-@Setter
-@Table(name = "REFRESH_TOKEN")
+@Builder
 public class RefreshToken {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-    @Column(name = "user_id")
-    private Long userId;
     private String token;
+    private Long userId;
     private String expiration;
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/jwt/repository/RefreshTokenRepository.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/jwt/repository/RefreshTokenRepository.java
@@ -1,11 +1,10 @@
 package buddyguard.mybuddyguard.jwt.repository;
 
 import buddyguard.mybuddyguard.jwt.entity.RefreshToken;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.data.keyvalue.repository.KeyValueRepository;
+import org.springframework.stereotype.Repository;
 
-public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    boolean existsByToken(String token);
-    @Transactional
-    void deleteByToken(String token);
+@Repository
+public interface RefreshTokenRepository extends KeyValueRepository<RefreshToken, String> {
+
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/jwt/service/TokenService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/jwt/service/TokenService.java
@@ -113,7 +113,7 @@ public class TokenService {
             throw new NotAccessTokenException(HttpStatus.UNAUTHORIZED, "unauthorized token");
         }
         // DB와 비교
-        if (!repository.existsByToken(refresh)) {
+        if (!repository.existsById(refresh)) {
             throw new TokenNotFoundException(HttpStatus.UNAUTHORIZED, "unauthorized token");
         }
 

--- a/be/src/main/java/buddyguard/mybuddyguard/login/handler/CustomSuccessHandler.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/login/handler/CustomSuccessHandler.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
     private final TokenService tokenService;
     private final RefreshTokenRepository repository;
 
@@ -49,7 +50,8 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         GrantedAuthority authority = iterator.next();
         String role = authority.getAuthority();
 
-        String refreshToken = tokenService.createJwt(userId, role, TokenType.REFRESH, 7 * 24 * 60 * 60L);
+        String refreshToken = tokenService.createJwt(userId, role, TokenType.REFRESH,
+                7 * 24 * 60 * 60L);
 
         // refresh 토큰 저장
         saveRefreshToken(userId, refreshToken, 7 * 24 * 60 * 60L);
@@ -63,6 +65,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     /**
      * 쿠키를 생성한다.
+     *
      * @param key
      * @param value
      * @return
@@ -76,10 +79,9 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     }
 
     private void saveRefreshToken(Long userId, String refreshToken, Long expiredSeconds) {
-        RefreshToken token = new RefreshToken();
-        token.setUserId(userId);
-        token.setToken(refreshToken);
-        token.setExpiration(String.valueOf(Date.from(Instant.now().plusSeconds(expiredSeconds))));
+        RefreshToken token = RefreshToken.builder().userId(userId).token(refreshToken)
+                .expiration(String.valueOf(Date.from(Instant.now().plusSeconds(expiredSeconds))))
+                .build();
         repository.save(token);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Closes #79 

## 📝 작업 내용

- MySQL에 저장했었던 refresh 토큰을 Redis에 저장하도록 변경했습니다!
    - 초대링크, 알림을 위해 Redis가 이미 적용되어 있었던 점. 
    - TTL 세팅 기능을 이용해 시간 경과 시, 자동적으로 삭제를 해주는 점이 큰 이점이라고 생각되어 저장 DB를 변경해보았습니다.