### PR TITLE
[feat] 펫의 식사 레코드 CRUD 구현

### DIFF
--- a/be/src/main/java/buddyguard/mybuddyguard/config/RedisConfig.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/config/RedisConfig.java
@@ -15,7 +15,7 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
         "buddyguard.mybuddyguard.login", "buddyguard.mybuddyguard.pet",
         "buddyguard.mybuddyguard.weight", "buddyguard.mybuddyguard.walk", 
         "buddyguard.mybuddyguard.alert", "buddyguard.mybuddyguard.walkimage",
-        "buddyguard.mybuddyguard.vaccination"})
+        "buddyguard.mybuddyguard.vaccination", "buddyguard.mybuddyguard.feed"})
 @EnableRedisRepositories(basePackages = {"buddyguard.mybuddyguard.invitation",
         "buddyguard.mybuddyguard.weight", "buddyguard.mybuddyguard.walk",
         "buddyguard.mybuddyguard.alert",  "buddyguard.mybuddyguard.jwt"})

--- a/be/src/main/java/buddyguard/mybuddyguard/feed/aop/UserPetGroupValidation.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/feed/aop/UserPetGroupValidation.java
@@ -1,0 +1,12 @@
+package buddyguard.mybuddyguard.feed.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserPetGroupValidation {
+}
+

--- a/be/src/main/java/buddyguard/mybuddyguard/feed/aop/UserPetGroupValidationAspect.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/feed/aop/UserPetGroupValidationAspect.java
@@ -1,0 +1,41 @@
+package buddyguard.mybuddyguard.feed.aop;
+
+import buddyguard.mybuddyguard.exception.PetNotFoundException;
+import buddyguard.mybuddyguard.exception.UserInformationNotFoundException;
+import buddyguard.mybuddyguard.exception.UserPetGroupException;
+import buddyguard.mybuddyguard.login.repository.UserRepository;
+import buddyguard.mybuddyguard.pet.repository.PetRepository;
+import buddyguard.mybuddyguard.pet.repository.UserPetRepository;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class UserPetGroupValidationAspect {
+
+    private final UserPetRepository userPetRepository;
+    private final PetRepository petRepository;
+    private final UserRepository userRepository;
+
+
+    @Before("@annotation(buddyguard.mybuddyguard.feed.aop.UserPetGroupValidation)")
+    public void checkUserPetConnection(JoinPoint joinPoint) {
+        // 파라미터의 순서를 맞춰줘야 하는 문제점 존재..
+        Long petId = (Long) joinPoint.getArgs()[0];
+        Long userId = (Long) joinPoint.getArgs()[1];
+
+        if (!petRepository.existsById(petId)) {
+            throw new PetNotFoundException();
+        }
+        if (!userRepository.existsById(userId)) {
+            throw new UserInformationNotFoundException();
+        }
+        if (!userPetRepository.existsByUserIdAndPetId(userId, petId)) {
+            throw new UserPetGroupException();
+        }
+    }
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/feed/controller/FeedController.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/feed/controller/FeedController.java
@@ -1,15 +1,19 @@
 package buddyguard.mybuddyguard.feed.controller;
 
+import buddyguard.mybuddyguard.feed.controller.request.FeedRecordCreateRequest;
 import buddyguard.mybuddyguard.feed.controller.response.FeedRecordResponse;
 import buddyguard.mybuddyguard.feed.service.FeedService;
 import buddyguard.mybuddyguard.login.dto.CustomOAuth2User;
 import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,6 +32,17 @@ public class FeedController {
         Long userId = customOAuth2User.getId();
         List<FeedRecordResponse> result = feedService.getPetFeedRecord(petId, userId);
         return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "펫의 먹이 기록을 생성하는 api", description = "펫의 먹이 기록을 새로 등록합니다. 먹이 양의 단위는 g, ml, L, 개(count) 입니다")
+    @PostMapping
+    public ResponseEntity<Void> createFeedRecord(
+            @PathVariable("petId") Long petId,
+            @RequestBody FeedRecordCreateRequest feedRecordCreateRequest,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        Long userId = customOAuth2User.getId();
+        feedService.save(petId, userId, feedRecordCreateRequest);
+        return new ResponseEntity<>(HttpStatus.CREATED);
     }
 
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/feed/controller/FeedController.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/feed/controller/FeedController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -43,6 +44,16 @@ public class FeedController {
         Long userId = customOAuth2User.getId();
         feedService.save(petId, userId, feedRecordCreateRequest);
         return new ResponseEntity<>(HttpStatus.CREATED);
+    }
+
+    @Operation(summary = "펫의 먹이 기록을 삭제하는 api", description = "펫의 특정 먹이 기록을 삭제합니다")
+    @DeleteMapping("/{feedId}")
+    public ResponseEntity<Void> deleteFeedRecord(@PathVariable("petId") Long petId,
+            @PathVariable("feedId") Long feedId,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        Long userId = customOAuth2User.getId();
+        feedService.delete(petId, userId, feedId);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/feed/controller/FeedController.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/feed/controller/FeedController.java
@@ -1,6 +1,7 @@
 package buddyguard.mybuddyguard.feed.controller;
 
 import buddyguard.mybuddyguard.feed.controller.request.FeedRecordCreateRequest;
+import buddyguard.mybuddyguard.feed.controller.request.FeedRecordUpdateRequest;
 import buddyguard.mybuddyguard.feed.controller.response.FeedRecordResponse;
 import buddyguard.mybuddyguard.feed.service.FeedService;
 import buddyguard.mybuddyguard.login.dto.CustomOAuth2User;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -56,4 +58,14 @@ public class FeedController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @Operation(summary = "펫의 먹이 기록을 업데이트하는 api", description = "펫의 먹이 기록 내용을 업데이트합니다")
+    @PatchMapping("/{feedId}")
+    public ResponseEntity<Void> updateFeedRecord(
+            @RequestBody FeedRecordUpdateRequest feedRecordUpdateRequest,
+            @PathVariable("petId") Long petId, @PathVariable("feedId") Long feedId,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        Long userId = customOAuth2User.getId();
+        feedService.update(petId, userId, feedId, feedRecordUpdateRequest);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/feed/controller/FeedController.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/feed/controller/FeedController.java
@@ -1,0 +1,33 @@
+package buddyguard.mybuddyguard.feed.controller;
+
+import buddyguard.mybuddyguard.feed.controller.response.FeedRecordResponse;
+import buddyguard.mybuddyguard.feed.service.FeedService;
+import buddyguard.mybuddyguard.login.dto.CustomOAuth2User;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/feed/{petId}")
+public class FeedController {
+
+    private final FeedService feedService;
+
+    @Operation(summary = "펫의 먹이 기록 전체를 조회하는 api", description = "해당 펫의 모든 먹이 기록을 조회합니다")
+    @GetMapping
+    public ResponseEntity<List<FeedRecordResponse>> getPetFeedRecord(
+            @PathVariable("petId") Long petId,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        Long userId = customOAuth2User.getId();
+        List<FeedRecordResponse> result = feedService.getPetFeedRecord(petId, userId);
+        return ResponseEntity.ok(result);
+    }
+
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/feed/controller/request/FeedRecordCreateRequest.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/feed/controller/request/FeedRecordCreateRequest.java
@@ -1,0 +1,26 @@
+package buddyguard.mybuddyguard.feed.controller.request;
+
+import buddyguard.mybuddyguard.feed.entity.FeedRecord;
+import buddyguard.mybuddyguard.feed.utils.AmountType;
+import buddyguard.mybuddyguard.feed.utils.FeedType;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record FeedRecordCreateRequest(
+        @NotNull LocalDateTime date,
+        @NotNull Long amount,
+        @NotNull @JsonProperty("amount_type") AmountType amountType,
+        @NotNull @JsonProperty("feed_type") FeedType feedType
+) {
+
+    public FeedRecord toEntity(Long petId) {
+        return FeedRecord.builder()
+                .petId(petId)
+                .date(this.date)
+                .amount(this.amount)
+                .amountType(this.amountType)
+                .feedType(this.feedType)
+                .build();
+    }
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/feed/controller/request/FeedRecordUpdateRequest.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/feed/controller/request/FeedRecordUpdateRequest.java
@@ -2,13 +2,14 @@ package buddyguard.mybuddyguard.feed.controller.request;
 
 import buddyguard.mybuddyguard.feed.utils.AmountType;
 import buddyguard.mybuddyguard.feed.utils.FeedType;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
 
 public record FeedRecordUpdateRequest(
         LocalDateTime date,
         Long amount,
-        AmountType amountType,
-        FeedType feedType
+        @JsonProperty("amount_type") AmountType amountType,
+        @JsonProperty("feed_type") FeedType feedType
 ) {
 
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/feed/controller/request/FeedRecordUpdateRequest.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/feed/controller/request/FeedRecordUpdateRequest.java
@@ -1,0 +1,14 @@
+package buddyguard.mybuddyguard.feed.controller.request;
+
+import buddyguard.mybuddyguard.feed.utils.AmountType;
+import buddyguard.mybuddyguard.feed.utils.FeedType;
+import java.time.LocalDateTime;
+
+public record FeedRecordUpdateRequest(
+        LocalDateTime date,
+        Long amount,
+        AmountType amountType,
+        FeedType feedType
+) {
+
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/feed/controller/response/FeedRecordResponse.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/feed/controller/response/FeedRecordResponse.java
@@ -1,0 +1,18 @@
+package buddyguard.mybuddyguard.feed.controller.response;
+
+import buddyguard.mybuddyguard.feed.utils.AmountType;
+import buddyguard.mybuddyguard.feed.utils.FeedType;
+import java.time.LocalDateTime;
+
+public record FeedRecordResponse(
+        Long id,
+        Long perId,
+        FeedType feedType,
+        LocalDateTime date,
+        String mainCategory,
+        String subCategory,
+        Long amount,
+        AmountType amountType
+) {
+
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/feed/entity/FeedRecord.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/feed/entity/FeedRecord.java
@@ -1,0 +1,71 @@
+package buddyguard.mybuddyguard.feed.entity;
+
+import buddyguard.mybuddyguard.feed.controller.response.FeedRecordResponse;
+import buddyguard.mybuddyguard.feed.utils.AmountType;
+import buddyguard.mybuddyguard.feed.utils.FeedType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "FEED_RECORDS")
+@Getter
+@Builder
+public class FeedRecord {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(name = "pet_id")
+    private Long petId;
+    private LocalDateTime date;
+    private Long amount;
+    @Column(name = "amount_type")
+    @Enumerated(EnumType.STRING)
+    private AmountType amountType;
+    @Column(name = "feed_type")
+    @Enumerated(EnumType.STRING)
+    private FeedType feedType;
+
+    public FeedRecordResponse toDto() {
+        return new FeedRecordResponse(
+                this.id,
+                this.petId,
+                this.feedType,
+                this.date,
+                "FEED",
+                this.feedType.name(),
+                this.amount,
+                this.amountType
+        );
+    }
+
+    public void update(Long amount, AmountType amountType, FeedType feedType,
+            LocalDateTime date) {
+        if (amount != null) {
+            this.amount = amount;
+        }
+        if (amountType != null) {
+            this.amountType = amountType;
+        }
+        if (feedType != null) {
+            this.feedType = feedType;
+        }
+        if (date != null) {
+            this.date = date;
+        }
+    }
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/feed/repository/FeedRepository.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/feed/repository/FeedRepository.java
@@ -1,0 +1,11 @@
+package buddyguard.mybuddyguard.feed.repository;
+
+import buddyguard.mybuddyguard.feed.entity.FeedRecord;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FeedRepository extends JpaRepository<FeedRecord, Long> {
+    List<FeedRecord> findByPetId(Long petId);
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/feed/service/FeedService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/feed/service/FeedService.java
@@ -1,6 +1,7 @@
 package buddyguard.mybuddyguard.feed.service;
 
 import buddyguard.mybuddyguard.feed.aop.UserPetGroupValidation;
+import buddyguard.mybuddyguard.feed.controller.request.FeedRecordCreateRequest;
 import buddyguard.mybuddyguard.feed.controller.response.FeedRecordResponse;
 import buddyguard.mybuddyguard.feed.entity.FeedRecord;
 import buddyguard.mybuddyguard.feed.repository.FeedRepository;
@@ -9,6 +10,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -30,4 +32,13 @@ public class FeedService {
         return response;
     }
 
+    @Transactional
+    @UserPetGroupValidation
+    public void save(Long petId, Long userId, FeedRecordCreateRequest feedRecordCreateRequest) {
+        FeedRecord feedRecord = feedRecordCreateRequest.toEntity(petId);
+
+        feedRepository.save(feedRecord);
+
+        log.info("SAVE FEED RECORD : {}번 펫 먹이 기록 등록", feedRecord.getPetId());
+    }
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/feed/service/FeedService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/feed/service/FeedService.java
@@ -3,6 +3,7 @@ package buddyguard.mybuddyguard.feed.service;
 import buddyguard.mybuddyguard.exception.RecordNotFoundException;
 import buddyguard.mybuddyguard.feed.aop.UserPetGroupValidation;
 import buddyguard.mybuddyguard.feed.controller.request.FeedRecordCreateRequest;
+import buddyguard.mybuddyguard.feed.controller.request.FeedRecordUpdateRequest;
 import buddyguard.mybuddyguard.feed.controller.response.FeedRecordResponse;
 import buddyguard.mybuddyguard.feed.entity.FeedRecord;
 import buddyguard.mybuddyguard.feed.repository.FeedRepository;
@@ -52,5 +53,19 @@ public class FeedService {
         feedRepository.delete(feedRecord);
 
         log.info("DELETE FEED RECORD : {}번 펫 먹이 기록 삭제", feedRecord.getPetId());
+    }
+
+    @Transactional
+    @UserPetGroupValidation
+    public void update(Long petId, Long userId, Long feedId, FeedRecordUpdateRequest feedRecordUpdateRequest) {
+        FeedRecord feedRecord = feedRepository.findById(feedId)
+                .orElseThrow(RecordNotFoundException::new);
+
+        feedRecord.update(feedRecordUpdateRequest.amount(), feedRecordUpdateRequest.amountType(),
+                feedRecordUpdateRequest.feedType(), feedRecordUpdateRequest.date());
+
+        feedRepository.save(feedRecord);
+
+        log.info("UPDATE FEED RECORE : {}번 펫의 {}번 기록 수정 완료", petId, feedRecord.getId());
     }
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/feed/service/FeedService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/feed/service/FeedService.java
@@ -1,5 +1,6 @@
 package buddyguard.mybuddyguard.feed.service;
 
+import buddyguard.mybuddyguard.exception.RecordNotFoundException;
 import buddyguard.mybuddyguard.feed.aop.UserPetGroupValidation;
 import buddyguard.mybuddyguard.feed.controller.request.FeedRecordCreateRequest;
 import buddyguard.mybuddyguard.feed.controller.response.FeedRecordResponse;
@@ -40,5 +41,16 @@ public class FeedService {
         feedRepository.save(feedRecord);
 
         log.info("SAVE FEED RECORD : {}번 펫 먹이 기록 등록", feedRecord.getPetId());
+    }
+
+    @Transactional
+    @UserPetGroupValidation
+    public void delete(Long petId, Long userId, Long feedId) {
+        FeedRecord feedRecord = feedRepository.findById(feedId)
+                .orElseThrow(RecordNotFoundException::new);
+
+        feedRepository.delete(feedRecord);
+
+        log.info("DELETE FEED RECORD : {}번 펫 먹이 기록 삭제", feedRecord.getPetId());
     }
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/feed/service/FeedService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/feed/service/FeedService.java
@@ -1,0 +1,33 @@
+package buddyguard.mybuddyguard.feed.service;
+
+import buddyguard.mybuddyguard.feed.aop.UserPetGroupValidation;
+import buddyguard.mybuddyguard.feed.controller.response.FeedRecordResponse;
+import buddyguard.mybuddyguard.feed.entity.FeedRecord;
+import buddyguard.mybuddyguard.feed.repository.FeedRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FeedService {
+
+    private final FeedRepository feedRepository;
+
+    @UserPetGroupValidation
+    public List<FeedRecordResponse> getPetFeedRecord(Long petId, Long userId) {
+
+        List<FeedRecord> feedRecords = feedRepository.findByPetId(petId);
+
+        List<FeedRecordResponse> response = new ArrayList<>();
+        for (FeedRecord feedRecord : feedRecords) {
+            response.add(feedRecord.toDto());
+        }
+
+        return response;
+    }
+
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/feed/utils/AmountType.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/feed/utils/AmountType.java
@@ -1,0 +1,25 @@
+package buddyguard.mybuddyguard.feed.utils;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Arrays;
+
+public enum AmountType {
+    L("l"),
+    ML("ml"),
+    G("g"),
+    COUNT("개");
+
+    private final String unitType;
+
+    AmountType(String unitType) {
+        this.unitType = unitType;
+    }
+
+    @JsonCreator
+    public static AmountType findByUnitType (String value) {
+        return Arrays.stream(AmountType.values())
+                .filter(type -> type.unitType.equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/feed/utils/FeedType.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/feed/utils/FeedType.java
@@ -1,0 +1,6 @@
+package buddyguard.mybuddyguard.feed.utils;
+
+public enum FeedType {
+    MEAL,
+    SNACK
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #130 

## 📝 작업 내용

- 특정 펫의 식사 기록 추가, 삭제, 수정, 조회 기능을 구현했습니다.
- 모든 작업은 시작 이전에 해당 로그인 유저와 대상 펫이 같은 그룹 안애 존재하는지 검증 후 진행됩니다.
- 펫의 식사를 추가하는 경우 미리 정의했었던 대로 다음과 같은 단위 사용 가능합니다.
    - m / M
    - 개 / COUNT
    - ml / ML
    - l / L
- 카테고리 분류는 다음과 같이 정의되었습니다.
    -  메인 : FEED
    - 서브 : MEAL / SNACK 