### PR TITLE
[feat] 펫 프로필 이미지 등록 및 수정 기능 구현

### DIFF
--- a/be/src/main/java/buddyguard/mybuddyguard/exception/S3ImageUploadFailException.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/exception/S3ImageUploadFailException.java
@@ -1,0 +1,10 @@
+package buddyguard.mybuddyguard.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class S3ImageUploadFailException extends BusinessException {
+
+    public S3ImageUploadFailException() {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 파일 업로드가 실패하였습니다.");
+    }
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/PetController.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/PetController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -78,6 +79,16 @@ public class PetController {
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
         Long userId = customOAuth2User.getId();
         service.update(userId, petId, petUpdateInformationRequest);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @Operation(summary = "유저의 펫의 프로필 이미지를 업데이트하는 api", description = "유저와 연결된 펫 중 한마리의 프로필 이미지를 업데이트합니다")
+    @PutMapping(value = "/{petId}/profileImage", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Void> updatePetProfileImage(@PathVariable("petId") Long petId,
+            @RequestPart(name = "image") MultipartFile imageFile,
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        Long userId = customOAuth2User.getId();
+        service.updateProfileImage(userId, petId, imageFile);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/PetController.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/PetController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -18,7 +19,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,11 +31,13 @@ public class PetController {
     private final PetService service;
 
     @Operation(summary = "펫을 등록하는 api", description = "유저에게 새로운 펫을 등록합니다")
-    @PostMapping
-    public ResponseEntity<Void> registerPet(@RequestBody PetRegisterRequest petRegisterRequest,
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Void> registerPet(
+            @RequestPart(name = "data") PetRegisterRequest petRegisterRequest,
+            @RequestPart(name = "image", required = false) MultipartFile imageFile,
             @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
         Long userId = customOAuth2User.getId();
-        service.register(petRegisterRequest, userId);
+        service.register(petRegisterRequest, imageFile, userId);
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
 

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/request/PetRegisterRequest.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/request/PetRegisterRequest.java
@@ -7,7 +7,6 @@ import java.time.LocalDate;
 
 public record PetRegisterRequest(
         @NotNull String name,
-        @JsonProperty("profile_image") String profileImage,
         @NotNull PetType type,
         @NotNull LocalDate birth
 ) {

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/request/PetUpdateInformationRequest.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/contoller/request/PetUpdateInformationRequest.java
@@ -5,7 +5,6 @@ import java.time.LocalDate;
 
 public record PetUpdateInformationRequest(
         String name,
-        @JsonProperty("profile_image") String profileImage,
         LocalDate birth
 ) {
 

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/entity/Pet.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/entity/Pet.java
@@ -48,15 +48,18 @@ public class Pet {
     @OneToMany(mappedBy = "pet")
     private List<PetWalkRecord> petWalkRecords;
 
-    public void update(String name, String profileImage, LocalDate birth) {
+    public void update(String name, LocalDate birth) {
         if (name != null) {
             this.name = name;
         }
-        if (profileImage != null) {
-            this.profileImage = profileImage;
-        }
         if (birth != null) {
             this.birth = birth;
+        }
+    }
+
+    public void updateProfileImage(String profileImage) {
+        if (profileImage != null) {
+            this.profileImage = profileImage;
         }
     }
 }

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/mapper/PetMapper.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/mapper/PetMapper.java
@@ -2,14 +2,13 @@ package buddyguard.mybuddyguard.pet.mapper;
 
 import buddyguard.mybuddyguard.pet.contoller.request.PetRegisterRequest;
 import buddyguard.mybuddyguard.pet.entity.Pet;
-import java.util.Optional;
 
 public class PetMapper {
 
-    public static Pet toEntity(PetRegisterRequest petRegisterRequest) {
+    public static Pet toEntity(PetRegisterRequest petRegisterRequest, String profileImage) {
         return Pet.builder()
                 .name(petRegisterRequest.name())
-                .profileImage(Optional.ofNullable(petRegisterRequest.profileImage()).orElse("None"))
+                .profileImage(profileImage)
                 .type(petRegisterRequest.type())
                 .birth(petRegisterRequest.birth())
                 .build();

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/service/PetService.java
@@ -58,8 +58,6 @@ public class PetService {
             imageUrl = "None";
         }
 
-        System.out.println(imageUrl);
-
         Users user = userRepository.findById(userId).orElseThrow(
                 UserInformationNotFoundException::new);
         if (!validateUser(user)) {
@@ -133,12 +131,33 @@ public class PetService {
         Pet pet = repository.findById(petId).orElseThrow(PetNotFoundException::new);
 
         pet.update(petUpdateInformationRequest.name(),
-                petUpdateInformationRequest.profileImage(),
                 petUpdateInformationRequest.birth());
 
         repository.save(pet);
 
         log.info("UPDATE PET : {}번 펫 정보 수정 완료", petId);
+    }
+
+    @Transactional
+    public void updateProfileImage(Long userId, Long petId, MultipartFile imageFile) {
+        String imageUrl;
+
+        if (imageFile != null && !imageFile.isEmpty()) {
+            imageUrl = petProfileImageService.uploadPetProfileImage(imageFile);
+        } else {
+            imageUrl = null;
+        }
+
+        if (!userPetRepository.existsByUserIdAndPetId(userId, petId)) {
+            throw new UserPetGroupException();
+        }
+        Pet pet = repository.findById(petId).orElseThrow(PetNotFoundException::new);
+
+        pet.updateProfileImage(imageUrl);
+
+        repository.save(pet);
+
+        log.info("UPDATE PET : {}번 펫 프로필 이미지 수정 완료", petId);
     }
 
     /**

--- a/be/src/main/java/buddyguard/mybuddyguard/pet/utils/MultipartJackson2HttpMessageConverter.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/pet/utils/MultipartJackson2HttpMessageConverter.java
@@ -1,0 +1,29 @@
+package buddyguard.mybuddyguard.pet.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Type;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false;
+    }
+}

--- a/be/src/main/java/buddyguard/mybuddyguard/walkimage/service/impl/PetProfileImageService.java
+++ b/be/src/main/java/buddyguard/mybuddyguard/walkimage/service/impl/PetProfileImageService.java
@@ -1,0 +1,44 @@
+package buddyguard.mybuddyguard.walkimage.service.impl;
+
+import buddyguard.mybuddyguard.exception.S3ImageUploadFailException;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+public class PetProfileImageService {
+
+    private final AmazonS3Client amazonS3Client;
+    private static final String PET_PROFILE_IMG_DIR = "petProfile";
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public PetProfileImageService(AmazonS3Client amazonS3Client) {
+        this.amazonS3Client = amazonS3Client;
+    }
+
+    public String uploadPetProfileImage(MultipartFile multipartFile) {
+        String fileName = PET_PROFILE_IMG_DIR + "/" + UUID.randomUUID() + "-"
+                + multipartFile.getOriginalFilename();
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(multipartFile.getSize());
+        metadata.setContentType(multipartFile.getContentType());
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            amazonS3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream, metadata));
+            return amazonS3Client.getUrl(bucket, fileName).toString();
+        } catch (IOException e) {
+            log.error("Error uploading file to S3", e);
+            throw new S3ImageUploadFailException();
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#155

## 📝 작업 내용

- 기존에는 펫 등록 시 임시로 String으로 저장하도록 되어 있었으나, 이를 실제로 이미지 파일을 등록하도록 변경했습니다.
- 펫 정보 수정 시에도 프로필 이미지를 업로드하여 수정할 수 있도록 변경했습니다.
    - PATCH 메서드에서 Multipart/form-data  사용 시 발생하는 문제를 고려하여, 일반 정보 수정 엔드포인트와 프로필 이미지 정보 수정 엔드포인트를 분리했습니다. [참고글](https://mangkyu.tistory.com/218)
- Swagger에서도 Multipart/form-data를 이용하여 테스트할 수 있도록 환경을 구성했습니다.

### 📷 스크린샷 (선택)
<img width="1469" alt="스크린샷 2024-11-01 오전 12 49 03" src="https://github.com/user-attachments/assets/ba53f871-16d0-43b8-82eb-4bba76e79be7">
