### PR TITLE
test: 산책 종료시 임계값과 데이터크기 명시적 확인을 위한 배포

### DIFF
--- a/fe/src/components/organisms/walk/WalkModal.tsx
+++ b/fe/src/components/organisms/walk/WalkModal.tsx
@@ -26,6 +26,7 @@ export interface WalkModalProps {
   canvasRef: React.MutableRefObject<HTMLCanvasElement | null>;
   changedPosition: PositionType | null;
   map: kakao.maps.Map | null;
+  threshold: number | undefined;
 }
 
 export interface FormDataType {
@@ -61,6 +62,7 @@ const initFormData: FormDataType = {
 };
 
 export default function WalkModal({
+  threshold,
   formTitle,
   timeRef,
   linePathRef,
@@ -132,7 +134,7 @@ export default function WalkModal({
       longitude: latLng.getLng(),
     }));
     setValue('path', pathData);
-    message.info(`pathData.length:${pathData.length}`);
+    message.info(`임계값 : ${threshold} \n pathData.length:${pathData.length}`);
   }, [linePathRef, setValue]);
 
   useEffect(() => {

--- a/fe/src/components/organisms/walk/WalkModal.tsx
+++ b/fe/src/components/organisms/walk/WalkModal.tsx
@@ -132,6 +132,7 @@ export default function WalkModal({
       longitude: latLng.getLng(),
     }));
     setValue('path', pathData);
+    message.info(`pathData.length:${pathData.length}`);
   }, [linePathRef, setValue]);
 
   useEffect(() => {

--- a/fe/src/components/pages/walk/GoWalk.tsx
+++ b/fe/src/components/pages/walk/GoWalk.tsx
@@ -130,6 +130,7 @@ export default function GoWalk({ threshold }: { threshold: number | undefined })
       )}
       {isStarted === 'done' && (
         <WalkModal
+          threshold={threshold}
           formTitle={'산책 완료'}
           timeRef={timeRef}
           linePathRef={linePathRef}

--- a/fe/src/hooks/useKakaoMap.ts
+++ b/fe/src/hooks/useKakaoMap.ts
@@ -1,3 +1,4 @@
+import { message } from 'antd';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { IsStartedType } from '@/components/pages/walk/GoWalk';


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #178 

## 📝 작업 내용

> message로 화면에 임계값, 산책경로 데이터의 크기를 확인할 수 있도록 한다.

### 📷 스크린샷 (선택)

> 변경된 내용을 시각적으로 확인할 수 있도록 스크린샷을 첨부해주세요.

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
