### PR TITLE
불필요한 위치 권한 사전 확인 로직 제거

### DIFF
--- a/fe/src/helper/kakaoMapHelpers.ts
+++ b/fe/src/helper/kakaoMapHelpers.ts
@@ -238,32 +238,10 @@ export const loadKakaoMapScript = (): Promise<void> => {
   });
 };
 
-/** 위치 권한 상태 확인 */
-const checkGeolocationPermission = async (): Promise<boolean> => {
-  if (!('permissions' in navigator)) {
-    console.log('Permissions API is not supported in this browser');
-    return true; // API가 없으면 직접 요청하도록 true 반환
-  }
-
-  try {
-    const permissionResult = await navigator.permissions.query({ name: 'geolocation' as PermissionName });
-    // "prompt" 상태도 허용하여 사용자에게 권한 요청 가능하도록
-    return permissionResult.state === 'granted' || permissionResult.state === 'prompt';
-  } catch (error) {
-    console.error('위치 권한 확인 중 오류 발생:', error);
-    return true; // 에러 발생 시 직접 요청해보도록 true 반환
-  }
-};
-
 /** 현재 위치 가져오기 */
 export const getcurrentPosition = async (): Promise<getcurrentLocationResultType> => {
   if (!('geolocation' in navigator)) {
     return { result: false, message: '🌍 Geolocation not supported', position: DEFAULT_MAP_POSITION };
-  }
-
-  const hasPermission = await checkGeolocationPermission();
-  if (!hasPermission) {
-    return { result: false, message: '🌍 permission was denied.', position: DEFAULT_MAP_POSITION };
   }
 
   return new Promise((resolve) => {

--- a/fe/src/helper/kakaoMapHelpers.ts
+++ b/fe/src/helper/kakaoMapHelpers.ts
@@ -240,9 +240,19 @@ export const loadKakaoMapScript = (): Promise<void> => {
 
 /** 위치 권한 상태 확인 */
 const checkGeolocationPermission = async (): Promise<boolean> => {
-  const permissionResult = await navigator.permissions.query({ name: 'geolocation' });
-  if (permissionResult.state === 'granted') return true;
-  return false;
+  if (!('permissions' in navigator)) {
+    console.log('Permissions API is not supported in this browser');
+    return true; // API가 없으면 직접 요청하도록 true 반환
+  }
+
+  try {
+    const permissionResult = await navigator.permissions.query({ name: 'geolocation' as PermissionName });
+    // "prompt" 상태도 허용하여 사용자에게 권한 요청 가능하도록
+    return permissionResult.state === 'granted' || permissionResult.state === 'prompt';
+  } catch (error) {
+    console.error('위치 권한 확인 중 오류 발생:', error);
+    return true; // 에러 발생 시 직접 요청해보도록 true 반환
+  }
 };
 
 /** 현재 위치 가져오기 */


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #190 

## 📝 작업 내용

> 위치 정보를 얻기 전에 `permissions.query()` API를 사용해 권한을 사전 확인하는 로직을 제거

### step1. 
권한이 "prompt" 상태일 때 사용자에게 권한 요청 다이얼로그가 표시되지 않는 문제가 있어서 `permissionResult.state === 'prompt'`상태까지 확인하도록 수정했습니다.

```diff
/** 위치 권한 상태 확인 */
const checkGeolocationPermission = async (): Promise<boolean> => {
-  const permissionResult = await navigator.permissions.query({ name: 'geolocation' });
-  if (permissionResult.state === 'granted') return true;
-  return false;

+  if (!('permissions' in navigator)) {
+    console.log('Permissions API is not supported in this browser');
+   return true; // API가 없으면 직접 요청하도록 true 반환
+  }
+
+  try {
+    const permissionResult = await navigator.permissions.query({ name: 'geolocation' as PermissionName });
+    // "prompt" 상태도 허용하여 사용자에게 권한 요청 가능하도록
+    return permissionResult.state === 'granted' || permissionResult.state === 'prompt';
+  } catch (error) {
+    console.error('위치 권한 확인 중 오류 발생:', error);
+    return true; // 에러 발생 시 직접 요청해보도록 true 반환
+  }
};
```

### step2.
그렇지만 결국 이 로직이 뭐든 true를 반환시켜야함을 깨닫고, 해당 로직을 삭제했습니다. 
브라우저의 기본 위치 권한 요청 메커니즘을 활용하는 것이 더 안정적이고 간결합니다.
```diff
 export const getcurrentPosition = async (): Promise<getcurrentLocationResultType> => {
   if (!('geolocation' in navigator)) {
     return { result: false, message: '🌍 Geolocation not supported', position: DEFAULT_MAP_POSITION };
   }

-  const hasPermission = await checkGeolocationPermission();
-  if (!hasPermission) {
-    return { result: false, message: '🌍 permission was denied.', position: DEFAULT_MAP_POSITION };
-  }

   return new Promise((resolve) => {
     // 재시도 로직 추가
     // ...
```

### step3.
checkGeolocationPermission 함수 자체도 더 이상 사용되지 않으므로 제거했습니다.
```diff
- /** 위치 권한 상태 확인 */
- const checkGeolocationPermission = async (): Promise<boolean> => {
-   if (!('permissions' in navigator)) {
-     console.log('Permissions API is not supported in this browser');
-    return true; // API가 없으면 직접 요청하도록 true 반환
-   }
- 
-   try {
-     const permissionResult = await navigator.permissions.query({ name: 'geolocation' as PermissionName });
-     // "prompt" 상태도 허용하여 사용자에게 권한 요청 가능하도록
-     return permissionResult.state === 'granted' || permissionResult.state === 'prompt';
-   } catch (error) {
-     console.error('위치 권한 확인 중 오류 발생:', error);
-     return true; // 에러 발생 시 직접 요청해보도록 true 반환
-   }
- };
```

### 📷 스크린샷 (선택)
![loadMap-fix-safari](https://github.com/user-attachments/assets/b8af4eae-8e08-4365-abc6-1f6e0f06756d)


## 변경 이유

### 1. 브라우저 호환성 문제
`permissions.query()` API는 브라우저마다 구현이 다르며, 일부 모바일 브라우저(특히 iOS Safari)에서 예상대로 작동하지 않습니다. 
MDN 문서에 따르면 Safari는 최근 버전에서만 지원하기 시작했습니다.
https://developer.mozilla.org/en-US/docs/Web/API/Permissions/query

### 2. 권한 관리 단순화
`navigator.geolocation.getCurrentPosition()`을 직접 호출하면 브라우저가 자동으로 적절한 권한 요청 UI를 표시하고 관리합니다. 
이는 W3C 표준이며 모든 브라우저에서 일관되게 구현되어 있습니다.

### 3. 안정성 향상
사전 권한 체크 시 "prompt" 상태를 잘못 처리하여 사용자에게 위치 권한 요청 다이얼로그가 표시되지 않던 문제가 해결됩니다.

### 4. 코드 간소화
불필요한 중간 단계를 제거하여 코드 흐름을 단순화하고 오류 가능성을 줄였습니다.

## 기대 효과

- 다양한 브라우저(특히 모바일 Safari, 모바일 Chrome)에서 위치 권한 요청이 더 안정적으로 작동합니다.
- 사용자에게 위치 정보 액세스 권한을 요청하는 일관된 경험을 제공합니다.
- 불필요한 코드가 제거되어 코드베이스가 더 단순해집니다.

## 테스트 결과

- [x] 웹 Chrome: 정상 작동
- [x] 웹 Safari: 정상 작동 (이전에는 권한 요청 다이얼로그가 표시되지 않았음)
- [ ] 모바일 Chrome: 정상 작동
- [ ] 모바일 Safari: 정상 작동